### PR TITLE
ci: use semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: node_js
+node_js:
+  - '8'
+  - '10'
+  - 'node'
+cache: npm
+notifications:
+  email: false
+branches:
+  except:
+    - '/^v\d+\.\d+\.\d+$/'
+jobs:
+  include:
+    - stage: deploy
+      if: branch == master && !fork
+      node_js: '8.9.1' # pre-installed version
+      script:
+        - npm install -g semantic-release@^15
+        - semantic-release

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "gets a meta file and its contents",
   "main": "index.js",
   "scripts": {
-    "test": "npm test"
+    "test": "echo 'No tests'"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
**Side note:** We should bump this (and other Meta packages) to at least v0.1.0 so that major versions and minor/patch versions are separated.

/cc @patrickleet 