### PR TITLE
fix: ctrl+c again

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,9 +50,12 @@ module.exports = function(options = {}) {
 
     `);
 
-    const answer = (prompt() || 'y').toLowerCase();
-    answer === 'x' && process.exit(0);
-    answer === 'y' && process.chdir(path.dirname(metaPath));
+    let answer = prompt();
+    if (answer == null) answer = 'x';
+    else answer = answer.toLowerCase() || 'y';
+
+    if (answer === 'x') process.exit(0);
+    if (answer === 'y') process.chdir(path.dirname(metaPath));
   }
 
   try {


### PR DESCRIPTION
The last fix defaulted to "y" instead of "x" when ctrl+c is used