### PR TITLE
Add format and save functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,3 +93,11 @@ module.exports = function(options = {}) {
 module.exports.getFileLocation = function() {
   return findUpsync('.meta', { cwd: process.cwd() });
 };
+
+module.exports.format = function(meta) {
+  return JSON.stringify(meta, null, 2) + '\n';
+};
+
+module.exports.save = function(meta) {
+  fs.writeFileSync(module.exports.getFileLocation(), module.exports.format(meta));
+};


### PR DESCRIPTION
The intention is to encapsulate `.meta` formatting. `format` can be used in https://github.com/mateodelnorte/meta-init/blob/master/bin/meta-init and `save` in https://github.com/mateodelnorte/meta-project/blob/master/bin/meta-project-add.

Changes to formatting:
- 2 spaces (`meta-init` was using 1)
- inserting a final newline.